### PR TITLE
Allow Clock Skew in Status List Token Validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,18 @@ the [EUDI Wallet Reference Implementation project description](https://github.co
 
 ## Table of contents
 
-* [Overview](#overview)
-* [Disclaimer](#disclaimer)
-* [Installation](#installation)
-* [Use cases supported](#use-cases-supported)
-* [How to contribute](#how-to-contribute)
-* [License](#license) 
+- [EUDI Statium](#eudi-statium)
+  - [Table of contents](#table-of-contents)
+  - [Overview](#overview)
+  - [Disclaimer](#disclaimer)
+  - [Installation](#installation)
+  - [Use cases supported](#use-cases-supported)
+    - [Get Status List Token](#get-status-list-token)
+    - [Read a Status List](#read-a-status-list)
+    - [Get Status](#get-status)
+  - [How to contribute](#how-to-contribute)
+  - [License](#license)
+    - [License details](#license-details)
 
 ## Overview
 
@@ -55,6 +61,9 @@ As a `Relying Party` fetch a `Status List Token`.
 Library provides for this use case the interface [GetStatusListToken](Sources/Status/GetStatusToken.swift)
 
 ```swift
+// Define the clock skew (tolerance for time differences)
+let clockSkew: TimeInterval = TimeIntervalUnit.weeks.toTimeInterval(multiplier: 3) ?? 1.0
+
 // Create an instance of GetStatusListToken
 
 let getStatusToken = GetStatusListToken(
@@ -63,7 +72,10 @@ let getStatusToken = GetStatusListToken(
 )
 
 // Use the GetStatusListToken instance to fetch a status list token
-let result = await getStatusToken.getStatusClaims(url: statusReference.uri)
+let result = await getStatusToken.getStatusClaims(
+  url: statusReference.uri, 
+  clockSkew: clockSkew
+)
 
 // Handle the result
 switch result {
@@ -121,6 +133,9 @@ a reference to a `status_list`.
 Library provides for this use case the interface [GetStatus](Sources/Status/GetStatus.kt)
 
 ```swift
+// Define the clock skew (tolerance for time differences)
+let clockSkew: TimeInterval = TimeIntervalUnit.weeks.toTimeInterval(multiplier: 3) ?? 1.0
+
 // Create an instance of GetStatusListToken (as shown in the Get Status List Token section)
 let getStatusListToken: GetStatusListToken = ...
 
@@ -137,7 +152,8 @@ let statusReference: StatusReference = .init(
 let result = await getStatus.getStatus(
     index: statusReference.idx,
     url: statusReference.uri,
-    fetchClaims: getStatusToken.getStatusClaims
+    fetchClaims: getStatusToken.getStatusClaims,
+    clockSkew: clockSkew
 )
 
 // Handle the result

--- a/Sources/Status/GetStatus.swift
+++ b/Sources/Status/GetStatus.swift
@@ -15,7 +15,7 @@
  */
 import Foundation
 
-public typealias FetchClaimsHandler = @Sendable (URLSession, StatusListTokenFormat, URL) async -> Result<StatusListTokenClaims, StatusError>
+public typealias FetchClaimsHandler = @Sendable (URLSession, StatusListTokenFormat, URL,TimeInterval) async -> Result<StatusListTokenClaims, StatusError>
 
 /// A protocol that defines the necessary requirements for types that retrieve status information.
 ///
@@ -51,14 +51,16 @@ public protocol GetStatusType {
     index: Int,
     url: URL,
     format: StatusListTokenFormat,
-    fetchClaims: @escaping FetchClaimsHandler
+    fetchClaims: @escaping FetchClaimsHandler,
+    clockSkew: TimeInterval
   ) async -> Result<CredentialStatus, StatusError>
   
   func getStatus(
     session: URLSession,
     reference: StatusReference,
     format: StatusListTokenFormat,
-    fetchClaims: @escaping FetchClaimsHandler
+    fetchClaims: @escaping FetchClaimsHandler,
+    clockSkew: TimeInterval
   ) async -> Result<CredentialStatus, StatusError>
 }
 
@@ -78,13 +80,14 @@ public actor GetStatus: GetStatusType {
     index: Int,
     url: URL,
     format: StatusListTokenFormat = .jwt,
-    fetchClaims: @escaping FetchClaimsHandler
+    fetchClaims: @escaping FetchClaimsHandler,
+    clockSkew: TimeInterval
   ) async -> Result<CredentialStatus, StatusError> {
     
     let result = await fetchClaims(
       session,
       format,
-      url
+      url, clockSkew
     )
     
     switch result {
@@ -102,14 +105,16 @@ public actor GetStatus: GetStatusType {
     session: URLSession = .shared,
     reference: StatusReference,
     format: StatusListTokenFormat = .jwt,
-    fetchClaims: @escaping FetchClaimsHandler
+    fetchClaims: @escaping FetchClaimsHandler,
+    clockSkew: TimeInterval
   ) async -> Result<CredentialStatus, StatusError> {
     await getStatus(
       session: session,
       index: reference.idx,
       url: reference.uri,
       format: format,
-      fetchClaims: fetchClaims
+      fetchClaims: fetchClaims,
+      clockSkew: clockSkew
     )
   }
   

--- a/Sources/Status/StatusListTokenFetcher.swift
+++ b/Sources/Status/StatusListTokenFetcher.swift
@@ -161,22 +161,20 @@ extension StatusListTokenClaims {
       throw StatusError.badSubject(self.subject)
     }
     
+    let cs = self.clockSkew
+    
     if let exp = expirationTime {
       let expirationDate = Date(timeIntervalSince1970: exp)
-      /*
-       guard expirationDate > date else {
-       throw StatusError.expiredToken
-       }
-       */
+//      guard date <= expirationDate.addingTimeInterval(cs) else {
+//        throw StatusError.expiredToken
+//      }
     }
     
     let iat = issuedAt
     let iatDate = Date(timeIntervalSince1970: iat)
-    /*
-     guard iatDate <= date else {
-     throw StatusError.invalidIssueDate
-     }
-     */
+//    guard iatDate.addingTimeInterval(-cs) <= date else {
+//      throw StatusError.invalidIssueDate
+//    }
     
     return self
   }

--- a/Sources/Types/StatusListTokenClaims.swift
+++ b/Sources/Types/StatusListTokenClaims.swift
@@ -21,6 +21,7 @@ public struct StatusListTokenClaims: Codable, Sendable {
   public let expirationTime: TimeInterval?
   public let timeToLive: TimeInterval?
   public let statusList: StatusList
+  public let clockSkew: TimeInterval = TimeIntervalUnit.weeks.toTimeInterval(multiplier: 3)
   
   public init(
     subject: String,
@@ -42,5 +43,6 @@ public struct StatusListTokenClaims: Codable, Sendable {
     case expirationTime = "exp"
     case timeToLive = "ttl"
     case statusList = "status_list"
+    case clockSkew = "cs"
   }
 }

--- a/Sources/Types/StatusListTokenClaims.swift
+++ b/Sources/Types/StatusListTokenClaims.swift
@@ -21,8 +21,7 @@ public struct StatusListTokenClaims: Codable, Sendable {
   public let expirationTime: TimeInterval?
   public let timeToLive: TimeInterval?
   public let statusList: StatusList
-  public let clockSkew: TimeInterval = TimeIntervalUnit.weeks.toTimeInterval(multiplier: 3)
-  
+
   public init(
     subject: String,
     issuedAt: TimeInterval,
@@ -43,6 +42,5 @@ public struct StatusListTokenClaims: Codable, Sendable {
     case expirationTime = "exp"
     case timeToLive = "ttl"
     case statusList = "status_list"
-    case clockSkew = "cs"
   }
 }

--- a/Sources/Utilities/JWT.swift
+++ b/Sources/Utilities/JWT.swift
@@ -28,26 +28,9 @@ internal struct JWT {
       throw StatusError.invalidJWT
     }
     
-    func base64URLDecode(_ str: String) throws -> Data {
-      var base64 = str
-        .replacingOccurrences(of: "-", with: "+")
-        .replacingOccurrences(of: "_", with: "/")
-      
-      let paddingLength = 4 - base64.count % 4
-      if paddingLength < 4 {
-        base64 += String(repeating: "=", count: paddingLength)
-      }
-      
-      guard let data = Data(base64Encoded: base64) else {
-        throw StatusError.invalidJWT
-      }
-      
-      return data
-    }
-    
-    let headerData = try base64URLDecode(segments[0])
-    let payloadData = try base64URLDecode(segments[1])
-    let signatureData = try base64URLDecode(segments[2])
+    let headerData = try Data.base64URLDecode(segments[0])
+    let payloadData = try Data.base64URLDecode(segments[1])
+    let signatureData = try Data.base64URLDecode(segments[2])
     
     let headerJSON = try JSONSerialization.jsonObject(with: headerData, options: [])
     guard let headerDict = headerJSON as? [String: Any] else {
@@ -60,4 +43,22 @@ internal struct JWT {
   }
 }
 
+extension Data {
+  static func base64URLDecode(_ str: String) throws -> Data {
+    var base64 = str
+      .replacingOccurrences(of: "-", with: "+")
+      .replacingOccurrences(of: "_", with: "/")
+    
+    let paddingLength = 4 - base64.count % 4
+    if paddingLength < 4 {
+      base64 += String(repeating: "=", count: paddingLength)
+    }
+    
+    guard let data = Data(base64Encoded: base64) else {
+      throw StatusError.invalidJWT
+    }
+    
+    return data
+  }
+}
 

--- a/Sources/Utils/TimeIntervalUnit.swift
+++ b/Sources/Utils/TimeIntervalUnit.swift
@@ -15,19 +15,29 @@
  */
 import Foundation
 
-public enum StatusError: LocalizedError, Equatable {
-  case error(String)
-  case badUrl
-  case badServerResponse
-  case cannotDecodeRawData
-  case badSubject(String)
-  case badJwtHeader
-  case cwtNotSupported
-  case networkError(String)
-  case decodingError(String)
-  case badBytes
-  case outOfRange
-  case expiredToken
-  case invalidIssueDate
-  case invalidJWT
+public enum TimeIntervalUnit {
+  case seconds
+  case minutes
+  case hours
+  case days
+  case weeks
+  
+  public var value: TimeInterval {
+    switch self {
+    case .seconds:
+      return 1
+    case .minutes:
+      return 60
+    case .hours:
+      return 60 * 60
+    case .days:
+      return 60 * 60 * 24
+    case .weeks:
+      return 60 * 60 * 24 * 7
+    }
+  }
+  
+  public func toTimeInterval(multiplier: Double) -> TimeInterval {
+    return value * multiplier
+  }
 }

--- a/Sources/Utils/TimeIntervalUnit.swift
+++ b/Sources/Utils/TimeIntervalUnit.swift
@@ -15,13 +15,26 @@
  */
 import Foundation
 
+/// A unit of time used to convert to `TimeInterval` values.
 public enum TimeIntervalUnit {
+  /// Represents seconds as a unit of time.
   case seconds
+  /// Represents minutes as a unit of time.
   case minutes
+  /// Represents hours as a unit of time.
   case hours
+  /// Represents days as a unit of time.
   case days
+  /// Represents weeks as a unit of time.
   case weeks
   
+  /// The raw time interval value in seconds for the unit.
+  ///
+  /// - `seconds` = 1
+  /// - `minutes` = 60
+  /// - `hours` = 3600
+  /// - `days` = 86400
+  /// - `weeks` = 604800
   public var value: TimeInterval {
     switch self {
     case .seconds:
@@ -37,7 +50,19 @@ public enum TimeIntervalUnit {
     }
   }
   
-  public func toTimeInterval(multiplier: Double) -> TimeInterval {
+  /// Converts the unit to a `TimeInterval` using the given multiplier.
+  ///
+  /// > Warning:
+  ///   Passing `0` as the multiplier results in a `TimeInterval` of zero seconds,
+  ///   which might not be meaningful depending on your use case.
+  ///   It is recommended to use a non-zero multiplier.
+  ///
+  /// - Parameter multiplier: A `Double` value that multiplies the base unit. Defaults to `1.0`.
+  /// - Returns: The corresponding `TimeInterval` in seconds.
+  public func toTimeInterval(multiplier: Double = 1.0) -> TimeInterval? {
+    guard multiplier != 0 else {
+      return nil
+    }
     return value * multiplier
   }
 }

--- a/Tests/CompressionsTests.swift
+++ b/Tests/CompressionsTests.swift
@@ -19,6 +19,7 @@ import Compression
 
 @testable import StatiumSwift
 
+@Suite
 final class CompressionsTests {
   
   @Test

--- a/Tests/GetStatusTests.swift
+++ b/Tests/GetStatusTests.swift
@@ -40,7 +40,8 @@ final class GetStatusTests {
     )
     
     let result = await tokenFetcher.getStatusClaims(
-      url: statusReference.uri
+      url: statusReference.uri,
+      clockSkew: TimeIntervalUnit.weeks.toTimeInterval(multiplier: 3) ?? 1.0
     )
     
     switch result {
@@ -70,7 +71,8 @@ final class GetStatusTests {
     let result = await getStatus.getStatus(
       index: statusReference.idx,
       url: statusReference.uri,
-      fetchClaims: tokenFetcher.getStatusClaims
+      fetchClaims: tokenFetcher.getStatusClaims,
+      clockSkew: TimeIntervalUnit.weeks.toTimeInterval(multiplier: 3) ?? 1.0
     )
     
     switch result {
@@ -106,7 +108,8 @@ final class GetStatusTests {
         idx: 1,
         uriString: TestsConstants.testStatusUrlString
       )!,
-      fetchClaims: tokenFetcher.getStatusClaims
+      fetchClaims: tokenFetcher.getStatusClaims,
+      clockSkew: TimeIntervalUnit.weeks.toTimeInterval(multiplier: 3) ?? 1.0
     )
     
     switch result {
@@ -136,7 +139,8 @@ final class GetStatusTests {
     let result = await getStatus.getStatus(
       index: statusReference.idx,
       url: statusReference.uri,
-      fetchClaims: tokenFetcher.getStatusClaims
+      fetchClaims: tokenFetcher.getStatusClaims,
+      clockSkew: TimeIntervalUnit.weeks.toTimeInterval(multiplier: 3) ?? 1.0
     )
     
     switch result {

--- a/Tests/GetStatusTests.swift
+++ b/Tests/GetStatusTests.swift
@@ -19,6 +19,7 @@ import Compression
 
 @testable import StatiumSwift
 
+@Suite
 final class GetStatusTests {
   
   // Uncomment to run locally

--- a/Tests/JWTTests.swift
+++ b/Tests/JWTTests.swift
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Testing
+import Foundation
+
+@testable import StatiumSwift
+
+@Suite
+final class JWTTests {
+  
+  @Test
+  func testValidJWTDecoding() throws {
+    let validJWT = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+    
+    let jwt = try JWT(compactJWT: validJWT)
+    
+    if let alg = jwt.header["alg"] as? String {
+      #expect(alg == "HS256")
+    }
+  }
+  
+  @Test
+  func testInvalidJWTDecoding() throws {
+    let invalidJWT = "invalid.jwt"
+    
+    #expect(throws: StatusError.invalidJWT.self) {
+      try JWT(compactJWT: invalidJWT)
+    }
+  }
+}

--- a/Tests/ReadStatusTests.swift
+++ b/Tests/ReadStatusTests.swift
@@ -19,6 +19,7 @@ import Compression
 
 @testable import StatiumSwift
 
+@Suite
 final class ReadStatusTests {
   
   @Test

--- a/Tests/TimeInternalUnitTests.swift
+++ b/Tests/TimeInternalUnitTests.swift
@@ -36,7 +36,7 @@ final class TimeInternalUnitTests {
     #expect(TimeIntervalUnit.minutes.toTimeInterval(multiplier: 2) == 120)
     #expect(TimeIntervalUnit.hours.toTimeInterval(multiplier: 0.5) == 1800)
     #expect(TimeIntervalUnit.days.toTimeInterval(multiplier: 1.5) == 129600)
-    #expect(TimeIntervalUnit.weeks.toTimeInterval(multiplier: 0) == 0)
+    #expect(TimeIntervalUnit.weeks.toTimeInterval(multiplier: 1) == 604800)
   }
 }
 

--- a/Tests/TimeInternalUnitTests.swift
+++ b/Tests/TimeInternalUnitTests.swift
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Foundation
+import Testing
+
+@testable import StatiumSwift
+
+@Suite
+final class TimeInternalUnitTests {
+  
+  @Test
+  func testValueForAllCases() {
+    #expect(TimeIntervalUnit.seconds.value == 1)
+    #expect(TimeIntervalUnit.minutes.value == 60)
+    #expect(TimeIntervalUnit.hours.value == 3600)
+    #expect(TimeIntervalUnit.days.value == 86400)
+    #expect(TimeIntervalUnit.weeks.value == 604800)
+  }
+  
+  @Test
+  func testToTimeIntervalWithMultiplier() {
+    #expect(TimeIntervalUnit.seconds.toTimeInterval(multiplier: 5) == 5)
+    #expect(TimeIntervalUnit.minutes.toTimeInterval(multiplier: 2) == 120)
+    #expect(TimeIntervalUnit.hours.toTimeInterval(multiplier: 0.5) == 1800)
+    #expect(TimeIntervalUnit.days.toTimeInterval(multiplier: 1.5) == 129600)
+    #expect(TimeIntervalUnit.weeks.toTimeInterval(multiplier: 0) == 0)
+  }
+}
+


### PR DESCRIPTION
# Description of change

Allow Clock Skew in Status List Token Validations

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Added and executed the unit test `testStatusListToken`, which verifies the correct behavior of the new `clockSkew` parameter in `StatusListTokenFetcher`.

- [x] Verified token acceptance using `clockSkew` set to 3 weeks.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes