### PR TITLE
[ci] add Fastlane lane for swiftlint autocorrect

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,2 +1,19 @@
 disabled_rules:
   - trailing_whitespace
+  - comment_spacing
+  - identifier_name
+  - cyclomatic_complexity
+  - function_body_length
+  - type_body_length
+  - function_parameter_count
+  - nesting
+  - file_length
+  - switch_case_alignment
+
+line_length: 300
+
+type_name:
+  min_length: 3
+  max_length:
+    warning: 50
+    error: 60

--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,6 @@ let package = Package(
     .testTarget(
       name: "StatiumSwiftTests",
       dependencies: ["StatiumSwift"]
-    ),
+    )
   ]
 )

--- a/Sources/Extensions/Data+Extenstions.swift
+++ b/Sources/Extensions/Data+Extenstions.swift
@@ -17,7 +17,7 @@ import Foundation
 import Compression
 
 public extension Data {
-  
+
   /// Decompresses the data using the ZLIB compression algorithm.
   ///
   /// This computed property attempts to decompress the data (excluding the first two bytes, which are assumed to be part of the ZLIB header).
@@ -45,12 +45,12 @@ public extension Data {
         nil,
         COMPRESSION_ZLIB
       )
-      return Data(bytes: buffer, count:read)
+      return Data(bytes: buffer, count: read)
     })
     buffer.deallocate()
     return result
   }
-  
+
   /// Decodes a Base64URL string into a byte array ([UInt8]).
   /// - Parameter base64Url: The Base64URL encoded string.
   /// - Returns: An optional `[UInt8]` array if decoding is successful.
@@ -58,17 +58,14 @@ public extension Data {
     var base64 = base64Url
       .replacingOccurrences(of: "-", with: "+")
       .replacingOccurrences(of: "_", with: "/")
-    
+
     // Add padding if necessary
     let paddingLength = (4 - (base64.count % 4)) % 4
     base64 += String(repeating: "=", count: paddingLength)
-    
+
     // Convert to Data
     guard let data = Data(base64Encoded: base64) else { return nil }
-    
+
     return [UInt8](data)
   }
 }
-
-
-

--- a/Sources/Services/NetworkingService.swift
+++ b/Sources/Services/NetworkingService.swift
@@ -28,24 +28,24 @@ public protocol NetworkingServiceType: Sendable {
 }
 
 public actor NetworkingService: NetworkingServiceType {
-  
+
   public let session: URLSession
-  
+
   public init(session: URLSession = .shared) {
     self.session = session
   }
-  
+
   public func get(
     url: URL,
     headers: [String: String]
   ) async -> Result<String, NetworkingError> {
-    
+
     var request = URLRequest(url: url)
     request.httpMethod = "GET"
     for (key, value) in headers {
       request.setValue(value, forHTTPHeaderField: key)
     }
-    
+
     do {
       let (data, response) = try await session.data(for: request)
       guard
@@ -57,15 +57,15 @@ public actor NetworkingService: NetworkingServiceType {
           )
         )
       }
-      
+
       guard let string = String(data: data, encoding: .utf8) else {
         return .failure(
           .error("Failed to decode JWT from response")
         )
       }
-      
+
       return .success(string)
-      
+
     } catch {
       return .failure(
         .error(
@@ -75,4 +75,3 @@ public actor NetworkingService: NetworkingServiceType {
     }
   }
 }
-

--- a/Sources/Spec/TokenStatusListSpec.swift
+++ b/Sources/Spec/TokenStatusListSpec.swift
@@ -18,7 +18,7 @@ import Foundation
 //// [Token Status List](https://www.ietf.org/archive/id/draft-ietf-oauth-status-list-10.html)
 public struct TokenStatusListSpec {
   public static let version: String = "draft-10"
-  
+
   public static let status: String = "status"
   public static let statusList: String = "status_list"
   public static let idx: String = "idx"
@@ -28,17 +28,16 @@ public struct TokenStatusListSpec {
   public static let aggregationUri: String = "aggregation_uri"
   public static let timeToLive: String = "ttl"
   public static let time: String = "time"
-  
+
   public static let statusValid: Byte = 0x00
   public static let statusInvalid: Byte = 0x01
   public static let statusSuspended: Byte = 0x02
   public static let statusApplicationSpecific: Byte = 0x03
   public static let statusApplicationSpecificRangeStart: Byte = 0x0b
   public static let statusApplicationSpecificRangeEnd: Byte = 0x0f
-  
+
   public static let mediaSubtypeStatusListJWT: String = "statuslist+jwt"
   public static let mediaTypeApplicationStatusListJWT: String = "application/\(Self.mediaSubtypeStatusListJWT)"
   public static let mediaSubtypeStatusListCWT: String = "statuslist+cwt"
   public static let mediaTypeApplicationStatusListCWT: String = "application/\(Self.mediaSubtypeStatusListCWT)"
 }
-

--- a/Sources/Status/ReadStatus.swift
+++ b/Sources/Status/ReadStatus.swift
@@ -21,13 +21,13 @@ import Foundation
 /// This actor takes a `BitsPerStatus` object and a byte array, and offers a method to retrieve
 /// a specific status byte at a given index, factoring in bit positions for the status bytes.
 public actor ReadStatus {
-  
+
   /// The number of bits used per status in the byte array.
   public let bitsPerStatus: BitsPerStatus
-  
+
   /// The byte array containing the status data.
   public let byteArray: [UInt8]
-  
+
   /// Initializes a `ReadStatus` actor with the given `BitsPerStatus` and byte array.
   ///
   /// - Parameters:
@@ -39,7 +39,7 @@ public actor ReadStatus {
     self.bitsPerStatus = bitsPerStatus
     self.byteArray = byteArray
   }
-  
+
   /// Reads the status at the specified index from the byte array.
   ///
   /// The function uses the `bitsPerStatus` to calculate the byte and bit positions of the status
@@ -55,22 +55,22 @@ public actor ReadStatus {
   /// print(status) // Prints the byte value at index 2
   /// ```
   public func readStatus(at index: Int) -> Byte? {
-    
+
     // Ensure the index is non-negative.
     guard index >= .zero else {
       return nil
     }
-    
+
     // Calculate the byte and bit position for the given index.
     let (bytePosition, bitPosition) = bitsPerStatus.byteAndBitPosition(
       index: UInt(index)
     )
-    
+
     // Attempt to retrieve the byte from the byte array.
     guard let byte = byteArray[safe: Int(bytePosition)] else {
       return nil
     }
-    
+
     // Read the status byte based on the bit position.
     let status = bitsPerStatus.readStatusByte(
       statusByte: byte,
@@ -81,7 +81,7 @@ public actor ReadStatus {
 }
 
 extension BitsPerStatus {
-  
+
   /// Calculates the byte position and bit position for a given status index.
   ///
   /// This function breaks down the index into a byte position and a bit position
@@ -100,7 +100,7 @@ extension BitsPerStatus {
     }()
     return (bytePosition, bitPosition)
   }
-  
+
   /// Reads a status byte at a specific bit position within the byte.
   ///
   /// This function extracts the status value from a byte by applying a bit mask
@@ -121,7 +121,7 @@ extension BitsPerStatus {
     case .four: 0b00001111
     case .eight: 0b11111111
     }
-    
+
     // Use the bit mask to isolate the relevant status bit and shift it to the right.
     let statusValue = (Int(statusByte) & (baseMask << bitPosition)) >> bitPosition
     return Byte(statusValue)

--- a/Sources/Types/BitsPerStatus.swift
+++ b/Sources/Types/BitsPerStatus.swift
@@ -20,19 +20,19 @@ import Foundation
 /// The enum defines the allowed bit sizes for status values, which are typically used to control
 /// the size of each status in a byte array. The possible values are 1, 2, 4, and 8 bits per status.
 public enum BitsPerStatus: Int, Codable, Sendable {
-  
+
   /// Represents 1 bit per status.
   case one = 1
-  
+
   /// Represents 2 bits per status.
   case two = 2
-  
+
   /// Represents 4 bits per status.
   case four = 4
-  
+
   /// Represents 8 bits per status.
   case eight = 8
-  
+
   /// Custom decoding to ensure that only valid values (1, 2, 4, 8) are allowed.
   ///
   /// This initializer allows `BitsPerStatus` to be decoded from an external data source. If the decoded
@@ -44,7 +44,7 @@ public enum BitsPerStatus: Int, Codable, Sendable {
   public init(from decoder: Decoder) throws {
     let container = try decoder.singleValueContainer()
     let value = try container.decode(Int.self)
-    
+
     // Ensure the decoded value matches one of the valid cases
     guard
       let validCase = BitsPerStatus(rawValue: value)
@@ -56,7 +56,7 @@ public enum BitsPerStatus: Int, Codable, Sendable {
     }
     self = validCase
   }
-  
+
   /// Custom encoding to encode the raw value of `BitsPerStatus`.
   ///
   /// This method encodes the raw integer value (1, 2, 4, or 8) when encoding a `BitsPerStatus` to an external

--- a/Sources/Types/CredentialStatus.swift
+++ b/Sources/Types/CredentialStatus.swift
@@ -15,16 +15,13 @@
  */
 import Foundation
 
-import Foundation
-
-/// The registered status types
 public enum CredentialStatus: Equatable, Sendable {
   case valid
   case invalid
   case suspended
   case applicationSpecific(UInt8)
   case reserved(UInt8)
-  
+
   /// Converts the status to a Byte representation
   public func toByte() -> UInt8 {
     switch self {
@@ -35,7 +32,7 @@ public enum CredentialStatus: Equatable, Sendable {
     case .reserved(let value): return value
     }
   }
-  
+
   /// Creates a `Status` given a `value`.
   public static func fromByte(_ value: UInt8) -> CredentialStatus {
     if value == TokenStatusListSpec.statusValid { return .valid }
@@ -44,7 +41,7 @@ public enum CredentialStatus: Equatable, Sendable {
     if isApplicationSpecific(value) { return .applicationSpecific(value) }
     return .reserved(value)
   }
-  
+
   /// Checks if the given `value` is application-specific
   private static func isApplicationSpecific(_ value: UInt8) -> Bool {
     let range = TokenStatusListSpec.statusApplicationSpecificRangeStart...TokenStatusListSpec.statusApplicationSpecificRangeEnd
@@ -52,5 +49,3 @@ public enum CredentialStatus: Equatable, Sendable {
     range.contains(value)
   }
 }
-
-

--- a/Sources/Types/StatusList.swift
+++ b/Sources/Types/StatusList.swift
@@ -19,7 +19,7 @@ public struct StatusList: Codable, Sendable {
   public let bytesPerStatus: BitsPerStatus
   public let compressedList: String
   public let aggregationUri: String?
-  
+
   public init(
     bytesPerStatus: BitsPerStatus,
     compressedList: String,
@@ -29,8 +29,8 @@ public struct StatusList: Codable, Sendable {
     self.compressedList = compressedList
     self.aggregationUri = aggregationUri
   }
-  
-  public enum CodingKeys : String, CodingKey {
+
+  public enum CodingKeys: String, CodingKey {
     case bytesPerStatus = "bits"
     case compressedList = "lst"
     case aggregationUri = "aggregation_uri"

--- a/Sources/Types/StatusListTokenClaims.swift
+++ b/Sources/Types/StatusListTokenClaims.swift
@@ -35,8 +35,8 @@ public struct StatusListTokenClaims: Codable, Sendable {
     self.timeToLive = timeToLive
     self.statusList = statusList
   }
-  
-  public enum CodingKeys : String, CodingKey {
+
+  public enum CodingKeys: String, CodingKey {
     case subject = "sub"
     case issuedAt = "iat"
     case expirationTime = "exp"

--- a/Sources/Types/StatusListTokenFormat.swift
+++ b/Sources/Types/StatusListTokenFormat.swift
@@ -21,14 +21,13 @@ import Foundation
 /// CWT format. It is used to distinguish between these two token formats in scenarios
 /// where the token format affects processing or validation.
 public enum StatusListTokenFormat: Sendable {
-  
+
   /// Represents the JSON Web Token (JWT) format.
   case jwt
-  
+
   /// Represents the CWT format.
   case cwt
 }
-
 
 public extension StatusListTokenFormat {
   var fieldHeaderValue: String {

--- a/Sources/Types/StatusReference.swift
+++ b/Sources/Types/StatusReference.swift
@@ -28,27 +28,27 @@ import Foundation
 public struct StatusReference: Codable, Sendable {
   public let idx: Int
   public let uri: URL
-  
+
   public init(idx: Int, uri: URL) {
     self.idx = idx
     self.uri = uri
   }
-  
+
   public init?(idx: Int, uriString: String) {
     guard let url = URL(string: uriString) else { return nil }
     self.idx = idx
     self.uri = url
   }
-  
+
   private enum CodingKeys: String, CodingKey {
     case idx
     case uri
   }
-  
+
   public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     self.idx = try container.decode(Int.self, forKey: .idx)
-    
+
     let uriString = try container.decode(String.self, forKey: .uri)
     guard let uri = URL(string: uriString) else {
       throw DecodingError.dataCorruptedError(
@@ -57,14 +57,13 @@ public struct StatusReference: Codable, Sendable {
         debugDescription: "Invalid URL format"
       )
     }
-    
+
     self.uri = uri
   }
-  
+
   public func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(idx, forKey: .idx)
     try container.encode(uri.absoluteString, forKey: .uri)
   }
 }
-

--- a/Sources/Types/TimeIntervalUnit.swift
+++ b/Sources/Types/TimeIntervalUnit.swift
@@ -27,7 +27,7 @@ public enum TimeIntervalUnit {
   case days
   /// Represents weeks as a unit of time.
   case weeks
-  
+
   /// The raw time interval value in seconds for the unit.
   ///
   /// - `seconds` = 1
@@ -49,7 +49,7 @@ public enum TimeIntervalUnit {
       return 60 * 60 * 24 * 7
     }
   }
-  
+
   /// Converts the unit to a `TimeInterval` using the given multiplier.
   ///
   /// - Parameter multiplier: A `Double` value that multiplies the base unit. Defaults to `1.0`.

--- a/Sources/Utilities/Decompress.swift
+++ b/Sources/Utilities/Decompress.swift
@@ -23,22 +23,22 @@ public protocol DecompressibleType: Sendable {
 }
 
 public struct Decompressible: DecompressibleType {
-  
+
   public typealias Decompressed = Data
 
   public var data: Data
-  
+
   public init(data: Data) {
     self.data = data
   }
-  
+
   public init() {
     self.data = Data()
   }
-  
+
   public mutating func setData(_ data: Data) {
     self.data = data
   }
-  
+
   public func decompress() -> Data { data.decompressed }
 }

--- a/Sources/Utilities/JWT.swift
+++ b/Sources/Utilities/JWT.swift
@@ -15,23 +15,21 @@
  */
 import Foundation
 
-import Foundation
-
 internal struct JWT {
   let header: [String: Any]
   let payload: Data
   let signature: Data?
-  
+
   init(compactJWT: String) throws {
     let segments = compactJWT.components(separatedBy: ".")
     guard segments.count == 3 else {
       throw StatusError.invalidJWT
     }
-    
+
     let headerData = try Data.base64URLDecode(segments[0])
     let payloadData = try Data.base64URLDecode(segments[1])
     let signatureData = try Data.base64URLDecode(segments[2])
-    
+
     do {
       let headerJSON = try JSONSerialization.jsonObject(with: headerData, options: [])
       guard let headerDict = headerJSON as? [String: Any] else {
@@ -41,7 +39,7 @@ internal struct JWT {
     } catch {
       throw StatusError.invalidJWT
     }
-    
+
     self.payload = payloadData
     self.signature = signatureData
   }
@@ -52,17 +50,16 @@ extension Data {
     var base64 = str
       .replacingOccurrences(of: "-", with: "+")
       .replacingOccurrences(of: "_", with: "/")
-    
+
     let paddingLength = 4 - base64.count % 4
     if paddingLength < 4 {
       base64 += String(repeating: "=", count: paddingLength)
     }
-    
+
     guard let data = Data(base64Encoded: base64) else {
       throw StatusError.invalidJWT
     }
-    
+
     return data
   }
 }
-

--- a/Tests/Extensions/DataExtensionTests.swift
+++ b/Tests/Extensions/DataExtensionTests.swift
@@ -20,11 +20,11 @@ import Foundation
 
 @Suite
 final class DataExtensionTests {
-  
+
   @Test
   func testBase64URLDecodeValidString() throws {
     let base64URL = "SFMyNTY=!"
-    
+
     do {
       let decodedData = try Data.base64URLDecode(base64URL)
       let decodedString = String(data: decodedData, encoding: .utf8)
@@ -33,21 +33,21 @@ final class DataExtensionTests {
       #expect(true, "Caught error: \(error). Expected successful decoding.")
     }
   }
-  
+
   @Test
   func testBase64URLDecodeInvalidString() throws {
     let invalidBase64URL = "invalid.base64.string"
-    
+
     #expect(throws: StatusError.invalidJWT.self) {
       try Data.base64URLDecode(invalidBase64URL)
     }
   }
-  
+
   @Test
   func testBase64URLDecodeEmptyString() throws {
     let emptyBase64URL = ""
     let decodedData = try Data.base64URLDecode(emptyBase64URL)
-    
+
     #expect(decodedData.count == 0)
   }
 }

--- a/Tests/Status/GetStatusTests.swift
+++ b/Tests/Status/GetStatusTests.swift
@@ -21,11 +21,11 @@ import Compression
 
 @Suite
 final class GetStatusTests {
-  
+
   // Uncomment to run locally
   // @Test
   func testStatusListToken() async throws {
-    
+
     guard let statusReference: StatusReference = .init(
       idx: 1,
       uriString: ConstantsTests.testStatusUrlString
@@ -33,17 +33,17 @@ final class GetStatusTests {
       Issue.record("Cannot decode status reference")
       return
     }
-    
+
     let tokenFetcher = StatusListTokenFetcher(
       verifier: VerifyStatusListTokenSignatureFactory.make(),
       date: Date()
     )
-    
+
     let result = await tokenFetcher.getStatusClaims(
       url: statusReference.uri,
       clockSkew: TimeIntervalUnit.weeks.toTimeInterval(multiplier: 3)
     )
-    
+
     switch result {
     case .success:
       #expect(true)
@@ -51,10 +51,10 @@ final class GetStatusTests {
       Issue.record("Invalid status")
     }
   }
-  
+
   // @Test
   func testStatusListFlowValid() async throws {
-    
+
     guard let statusReference: StatusReference = .init(
       idx: 1,
       uriString: ConstantsTests.testStatusUrlString
@@ -62,19 +62,19 @@ final class GetStatusTests {
       Issue.record("Cannot decode status reference")
       return
     }
-    
+
     let getStatus = GetStatus()
     let tokenFetcher = StatusListTokenFetcher(
       verifier: VerifyStatusListTokenSignatureFactory.make()
     )
-    
+
     let result = await getStatus.getStatus(
       index: statusReference.idx,
       url: statusReference.uri,
       fetchClaims: tokenFetcher.getStatusClaims,
       clockSkew: TimeIntervalUnit.weeks.toTimeInterval(multiplier: 3)
     )
-    
+
     switch result {
     case .success(let status):
       switch status {
@@ -89,20 +89,20 @@ final class GetStatusTests {
       case .reserved:
         Issue.record("Invalid status")
       }
-      
+
     case .failure:
       Issue.record("Invalid status")
     }
   }
-  
+
   // @Test
   func testStatusListFlowValidWithStatusReference() async throws {
-    
+
     let getStatus = GetStatus()
     let tokenFetcher = StatusListTokenFetcher(
       verifier: VerifyStatusListTokenSignatureFactory.make()
     )
-    
+
     let result = await getStatus.getStatus(
       reference: .init(
         idx: 1,
@@ -111,7 +111,7 @@ final class GetStatusTests {
       fetchClaims: tokenFetcher.getStatusClaims,
       clockSkew: TimeIntervalUnit.weeks.toTimeInterval(multiplier: 3)
     )
-    
+
     switch result {
     case .success(let status):
       #expect(status == .valid)
@@ -119,10 +119,10 @@ final class GetStatusTests {
       Issue.record("Invalid status")
     }
   }
-  
+
   // @Test
   func testStatusListFlowInvalid() async throws {
-    
+
     guard let statusReference: StatusReference = .init(
       idx: 2000,
       uriString: ConstantsTests.testStatusUrlString
@@ -130,19 +130,19 @@ final class GetStatusTests {
       Issue.record("Cannot decode status reference")
       return
     }
-    
+
     let getStatus = GetStatus()
     let tokenFetcher = StatusListTokenFetcher(
       verifier: VerifyStatusListTokenSignatureFactory.make()
     )
-    
+
     let result = await getStatus.getStatus(
       index: statusReference.idx,
       url: statusReference.uri,
       fetchClaims: tokenFetcher.getStatusClaims,
       clockSkew: TimeIntervalUnit.weeks.toTimeInterval(multiplier: 3)
     )
-    
+
     switch result {
     case .success:
       Issue.record("Invalid status")

--- a/Tests/Status/ReadStatusTests.swift
+++ b/Tests/Status/ReadStatusTests.swift
@@ -21,7 +21,7 @@ import Compression
 
 @Suite
 final class ReadStatusTests {
-  
+
   @Test
   func testBitsPerStatusOneOps() async {
     // Example 1: 1 bit per status
@@ -35,94 +35,94 @@ final class ReadStatusTests {
     // Status at index 5: 1
     // Status at index 6: 0
     // Status at index 7: 1 (leftmost bit)
-    
+
     let readStatus = ReadStatus(bitsPerStatus: .one, byteArray: [0xaa])
-    var result: Byte? = nil
-    
+    var result: Byte?
+
     result = await readStatus.readStatus(at: 0)
     #expect(result == 0)
-    
+
     result = await readStatus.readStatus(at: 1)
     #expect(result == 1)
-    
+
     result = await readStatus.readStatus(at: 2)
     #expect(result == 0)
-    
+
     result = await readStatus.readStatus(at: 3)
     #expect(result == 1)
-    
+
     result = await readStatus.readStatus(at: 4)
     #expect(result == 0)
-    
+
     result = await readStatus.readStatus(at: 5)
     #expect(result == 1)
-    
+
     result = await readStatus.readStatus(at: 6)
     #expect(result == 0)
-    
+
     result = await readStatus.readStatus(at: 7)
     #expect(result == 1)
   }
-  
+
   @Test
   func testBitsPerStatusOneOps2() async {
     // Test with multiple bytes
     // Byte 0: 10101010 (0xAA)
     // Byte 1: 11001100 (0xCC)
     let readStatus = ReadStatus(bitsPerStatus: .one, byteArray: [0xaa, 0xcc])
-    var result: Byte? = nil
-    
+    var result: Byte?
+
     // First byte (index 0-7)
     result = await readStatus.readStatus(at: 0)
     #expect(result == 0)
-    
+
     result = await readStatus.readStatus(at: 1)
     #expect(result == 1)
-    
+
     result = await readStatus.readStatus(at: 2)
     #expect(result == 0)
-    
+
     result = await readStatus.readStatus(at: 3)
     #expect(result == 1)
-    
+
     result = await readStatus.readStatus(at: 4)
     #expect(result == 0)
-    
+
     result = await readStatus.readStatus(at: 5)
     #expect(result == 1)
-    
+
     result = await readStatus.readStatus(at: 6)
     #expect(result == 0)
-    
+
     result = await readStatus.readStatus(at: 7)
     #expect(result == 1)
-    
+
     // Second byte (index 8-15)
     result = await readStatus.readStatus(at: 8)
     #expect(result == 0)
-    
+
     result = await readStatus.readStatus(at: 9)
     #expect(result == 0)
-    
+
     result = await readStatus.readStatus(at: 10)
     #expect(result == 1)
-    
+
     result = await readStatus.readStatus(at: 11)
     #expect(result == 1)
-    
+
     result = await readStatus.readStatus(at: 12)
     #expect(result == 0)
-    
+
     result = await readStatus.readStatus(at: 13)
     #expect(result == 0)
-    
+
     result = await readStatus.readStatus(at: 14)
     #expect(result == 1)
-    
+
     result = await readStatus.readStatus(at: 15)
     #expect(result == 1)
   }
-  
+
   @Test
   func testBitsPerStatusTwoOps() async {
     // Example 2: 2 bits per status
@@ -133,56 +133,56 @@ final class ReadStatusTests {
     // Status at index 2: 10 (binary) = 2 (decimal)
     // Status at index 3: 11 (binary) = 3 (decimal)
     let readStatus = ReadStatus(bitsPerStatus: .two, byteArray: [0xe4])
-    var result: Byte? = nil
-    
+    var result: Byte?
+
     result = await readStatus.readStatus(at: 0)
     #expect(result == 0)
-    
+
     result = await readStatus.readStatus(at: 1)
     #expect(result == 1)
-    
+
     result = await readStatus.readStatus(at: 2)
     #expect(result == 2)
-    
+
     result = await readStatus.readStatus(at: 3)
     #expect(result == 3)
   }
-  
+
   @Test
   func testBitsPerStatusTwoOps2() async {
-    
+
     // Test with multiple bytes
     // Byte 0: 11100100 (0xE4)
     // Byte 1: 10011011 (0x9B)
-    
+
     let readStatus = ReadStatus(bitsPerStatus: .two, byteArray: [0xe4, 0x9b])
-    var result: Byte? = nil
-    
+    var result: Byte?
+
     result = await readStatus.readStatus(at: 0)
     #expect(result == 0)
-    
+
     result = await readStatus.readStatus(at: 1)
     #expect(result == 1)
-    
+
     result = await readStatus.readStatus(at: 2)
     #expect(result == 2)
-    
+
     result = await readStatus.readStatus(at: 3)
     #expect(result == 3)
-    
+
     result = await readStatus.readStatus(at: 4)
     #expect(result == 3)
-    
+
     result = await readStatus.readStatus(at: 5)
     #expect(result == 2)
-    
+
     result = await readStatus.readStatus(at: 6)
     #expect(result == 1)
-    
+
     result = await readStatus.readStatus(at: 7)
     #expect(result == 2)
   }
-  
+
   @Test
   func testBitsPerStatusFourOps() async {
     // Example 3: 4 bits per status
@@ -191,38 +191,38 @@ final class ReadStatusTests {
     // Status at index 0: 0000 (binary) = 0 (decimal)
     // Status at index 1: 1111 (binary) = 15 (decimal)
     let readStatus = ReadStatus(bitsPerStatus: .four, byteArray: [0xf0])
-    var result: Byte? = nil
-    
+    var result: Byte?
+
     result = await readStatus.readStatus(at: 0)
     #expect(result == 0)
-    
+
     result = await readStatus.readStatus(at: 1)
     #expect(result == 15)
   }
-  
+
   @Test
   func testBitsPerStatusFourOps2() async {
     // Test with multiple bytes
     // Byte 0: 11110000 (0xF0)
     // Byte 1: 10100101 (0xA5)
     let readStatus = ReadStatus(bitsPerStatus: .four, byteArray: [0xf0, 0xa5])
-    var result: Byte? = nil
-    
+    var result: Byte?
+
     // First byte (index 0-1)
     result = await readStatus.readStatus(at: 0)
     #expect(result == 0)
-    
+
     result = await readStatus.readStatus(at: 1)
     #expect(result == 15)
-    
+
     // Second byte (index 2-3)
     result = await readStatus.readStatus(at: 2)
     #expect(result == 5)
-    
+
     result = await readStatus.readStatus(at: 3)
     #expect(result == 10)
   }
-  
+
   @Test
   func testBitsPerStatusEightOps() async {
     // Example 4: 8 bits per status
@@ -231,25 +231,24 @@ final class ReadStatusTests {
     // Byte 1: 00000000 (binary) = 0x00 (hex) = 0 (decimal)
     // Byte 2: 10101010 (binary) = 0xAA (hex) = 170 (decimal)
     let readStatus = ReadStatus(bitsPerStatus: .eight, byteArray: [0xff, 0x00, 0xaa])
-    var result: Byte? = nil
-    
+    var result: Byte?
+
     result = await readStatus.readStatus(at: 0)
     #expect(result == 255)
-    
+
     result = await readStatus.readStatus(at: 1)
     #expect(result == 0)
-    
+
     result = await readStatus.readStatus(at: 2)
     #expect(result == 170)
   }
-  
+
   @Test
   func testNegativeIndexOps() async {
     let readStatus = ReadStatus(bitsPerStatus: .one, byteArray: [0x00])
-    var result: Byte? = nil
-    
+    var result: Byte?
+
     result = await readStatus.readStatus(at: -1)
     #expect(result == nil)
   }
 }
-

--- a/Tests/Types/BitsPerStatusTests.swift
+++ b/Tests/Types/BitsPerStatusTests.swift
@@ -20,22 +20,22 @@ import Foundation
 
 @Suite
 final class BitsPerStatusTests {
-  
+
   @Test
   func testBitsPerStatusEncoding() throws {
-    
+
     let bitsPerStatus: BitsPerStatus = .four
     let encodedData = try JSONEncoder().encode(bitsPerStatus)
     let decodedValue = try JSONDecoder().decode(Int.self, from: encodedData)
-    
+
     #expect(decodedValue == bitsPerStatus.rawValue)
   }
-  
+
   @Test
   func testInvalidBitsPerStatusEncoding() throws {
     let invalidRawValue = 3
     let jsonData = try JSONEncoder().encode(invalidRawValue)
-    
+
     #expect(throws: DecodingError.self) {
       try JSONDecoder().decode(BitsPerStatus.self, from: jsonData)
     }

--- a/Tests/Types/CredentialStatusTests.swift
+++ b/Tests/Types/CredentialStatusTests.swift
@@ -20,68 +20,67 @@ import Foundation
 
 @Suite
 final class CredentialStatusTests {
-  
+
   @Test
   func testValidStatus() {
     let status = CredentialStatus.valid
     #expect(status.toByte() == 0x00)
   }
-  
+
   @Test
   func testInvalidStatus() {
     let status = CredentialStatus.invalid
     #expect(status.toByte() == 0x01)
   }
-  
+
   @Test
   func testSuspendedStatus() {
     let status = CredentialStatus.suspended
     #expect(status.toByte() == 0x02)
   }
-  
+
   @Test
   func testSpecificStatus() {
     let value: UInt8 = 100
     let status = CredentialStatus.applicationSpecific(value)
     #expect(status.toByte() == value)
   }
-  
+
   @Test
   func testReservedStatus() {
     let value: UInt8 = 200
     let status = CredentialStatus.reserved(value)
     #expect(status.toByte() == value)
   }
-  
+
   @Test
   func testValidByte() {
     let byte: UInt8 = 0x00
     let status = CredentialStatus.fromByte(byte)
     #expect(status == .valid)
   }
-  
+
   @Test
   func testInvalidByte() {
     let byte: UInt8 = 0x01
     let status = CredentialStatus.fromByte(byte)
     #expect(status == .invalid)
   }
-  
-  
+
   @Test
   func testSuspendedByte() {
     let byte: UInt8 = 0x02
     let status = CredentialStatus.fromByte(byte)
     #expect(status == .suspended)
   }
-  
+
   @Test
   func testSpecificByte() {
     let byte: UInt8 = 0x03
     let status = CredentialStatus.fromByte(byte)
     #expect(status ==  .applicationSpecific(byte))
   }
-  
+
   @Test
   func testReservedByte() {
     let byte: UInt8 = 0x04

--- a/Tests/Types/StatusReferenceTests.swift
+++ b/Tests/Types/StatusReferenceTests.swift
@@ -20,23 +20,23 @@ import Foundation
 
 @Suite
 final class StatusReferenceTests {
-  
+
   @Test
   func testInitializationWithValidURLString() throws {
     let statusReference = StatusReference(idx: 1, uriString: "https://statium.com")
-    
+
     #expect(statusReference?.idx == 1)
     #expect(statusReference?.uri.absoluteString == "https://statium.com")
   }
-  
+
   @Test
   func testInitializationWithInvalidURLString() throws {
     let statusReference = StatusReference(idx: 1, uriString: "invalid_url_string")
-    
+
     #expect(statusReference != nil)
     #expect(statusReference?.uri.absoluteString == "invalid_url_string")
   }
-  
+
   @Test
   func testValidStatusReferenceDecoding() throws {
     let json = """
@@ -45,10 +45,10 @@ final class StatusReferenceTests {
               "uri": "https://statium.com"
           }
           """
-    
+
     let data = json.data(using: .utf8)!
     let statusReference = try JSONDecoder().decode(StatusReference.self, from: data)
-    
+
     #expect(statusReference.idx == 1)
     #expect(statusReference.uri.absoluteString == "https://statium.com")
   }

--- a/Tests/Types/TimeInternalUnitTests.swift
+++ b/Tests/Types/TimeInternalUnitTests.swift
@@ -20,7 +20,7 @@ import Testing
 
 @Suite
 final class TimeInternalUnitTests {
-  
+
   @Test
   func testValueForAllCases() {
     #expect(TimeIntervalUnit.seconds.value == 1)
@@ -29,7 +29,7 @@ final class TimeInternalUnitTests {
     #expect(TimeIntervalUnit.days.value == 86400)
     #expect(TimeIntervalUnit.weeks.value == 604800)
   }
-  
+
   @Test
   func testToTimeIntervalWithMultiplier() {
     #expect(TimeIntervalUnit.seconds.toTimeInterval(multiplier: 5) == 5)
@@ -39,4 +39,3 @@ final class TimeInternalUnitTests {
     #expect(TimeIntervalUnit.weeks.toTimeInterval(multiplier: 1) == 604800)
   }
 }
-

--- a/Tests/Utilities/CompressionsTests.swift
+++ b/Tests/Utilities/CompressionsTests.swift
@@ -21,44 +21,44 @@ import Compression
 
 @Suite
 final class CompressionsTests {
-  
+
   @Test
   func testDecomressionShorter() {
-    
+
     let bytes: [UInt8] = [0x78, 0xda, 0xdb, 0xb9, 0x18, 0x00, 0x02, 0x17, 0x01, 0x5d]
     let decodedBytes = Data.fromBase64URL("eNrbuRgAAhcBXQ")
-    
+
     #expect(bytes == decodedBytes!)
-    
+
     let decompressed = Decompressible(data: Data(decodedBytes!)).decompress()
-    
+
     #expect(decompressed[0] == 0xb9)
     #expect(decompressed[1] == 0xa3)
   }
-  
+
   @Test
   func testDecomressionLonger() {
-    
+
     let bytes: [UInt8] = [0x78, 0xda, 0x3b, 0xe9, 0xf2, 0x13, 0x00, 0x03, 0xdf, 0x02, 0x07]
     let decodedBytes = Data.fromBase64URL("eNo76fITAAPfAgc")
-    
+
     #expect(bytes == decodedBytes!)
-    
+
     let decompressed = Decompressible(data: Data(decodedBytes!)).decompress()
 
     #expect(decompressed[0] == 0xc9)
     #expect(decompressed[1] == 0x44)
     #expect(decompressed[2] == 0xf9)
   }
-  
+
   @Test
   func testDecomression() {
-    
+
    let bytes: [UInt8] = [0x78, 0xda, 0x63, 0x60, 0x40, 0x02, 0x00, 0x00, 0x0d, 0x00, 0x01]
     let decodedBytes = Data.fromBase64URL("eNpjYEACAAANAAE")
-    
+
     #expect(bytes == decodedBytes!)
-    
+
     let decompressed = Decompressible(data: Data(decodedBytes!)).decompress()
 
     #expect(decompressed[0] == 0x00)

--- a/Tests/Utilities/JWTTests.swift
+++ b/Tests/Utilities/JWTTests.swift
@@ -20,58 +20,58 @@ import Foundation
 
 @Suite
 final class JWTTests {
-  
+
   @Test
   func testValidJWTDecoding() throws {
     let validJWT = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
-    
+
     let jwt = try JWT(compactJWT: validJWT)
-    
+
     if let alg = jwt.header["alg"] as? String {
       #expect(alg == "HS256")
     }
   }
-  
+
   @Test
   func testInvalidJWTDecoding() throws {
     let invalidJWT = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
-    
+
     #expect(throws: StatusError.invalidJWT.self) {
       try JWT(compactJWT: invalidJWT)
     }
   }
-  
+
   @Test
   func testInvalidJWTDecodingUsingTwoSegments() throws {
     let invalidJWT = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ"
-    
+
     #expect(throws: StatusError.invalidJWT.self) {
       try JWT(compactJWT: invalidJWT)
     }
   }
-  
+
   @Test
   func testInvalidJWTDecodingUsingThreeSegments() throws {
     let invalidJWT = "eyJhbGciOiJIUzI1NIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMef36POk6yJV_adQssw5c"
-    
+
     #expect(throws: StatusError.invalidJWT.self) {
       try JWT(compactJWT: invalidJWT)
     }
   }
-  
+
   @Test
   func testInvalidJWTDecodingWithCorruptedBase64() throws {
     let invalidJWT = "invalid-@@.jwt.signature"
-    
+
     #expect(throws: StatusError.invalidJWT.self) {
       try JWT(compactJWT: invalidJWT)
     }
   }
-  
+
   @Test
   func testInvalidJWTDecodingWithInvalidJSONHeader() throws {
     let invalidJWT = "aW52YWxpZA.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
-    
+
     #expect(throws: StatusError.invalidJWT.self) {
       try JWT(compactJWT: invalidJWT)
     }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -43,8 +43,13 @@ platform :ios do
     )
   end
   
+  desc "Fix lint issues"
+  lane :lint_fix do
+    sh "swiftlint lint --fix --config ../.swiftlint.yml --quiet ../"
+  end
+
   desc "Code coverage"
-  lane :coverage do
+  lane :code_coverage do
 
     FileUtils.remove_dir "../xcov_output", true
     

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -31,10 +31,18 @@ Runs unit tests
 
 Builds the package
 
-### ios coverage
+### ios lint_fix
 
 ```sh
-[bundle exec] fastlane ios coverage
+[bundle exec] fastlane ios lint_fix
+```
+
+Fix lint issues
+
+### ios code_coverage
+
+```sh
+[bundle exec] fastlane ios code_coverage
 ```
 
 Code coverage


### PR DESCRIPTION
# Description of change
Added a Fastlane lane that runs `swiftlint --fix` to automatically correct linting issues and improve code consistency.

# How Has This Been Tested?
Tested locally by running the new lane and verifying that it fixes linting issues as expected.

# Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (N/A)
- [ ] I have made corresponding changes to the readme (N/A)
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works (N/A)
- [x] New and existing unit tests pass locally with my changes